### PR TITLE
Fix string localisation

### DIFF
--- a/libcore/SKCore.m
+++ b/libcore/SKCore.m
@@ -165,7 +165,7 @@ NSString*sSKCoreGetLocalisedString(NSString*theString)
   NSString *theResult = NSLocalizedString(theString, nil);
   //NSLog(@"DEBUG: theResult for (%@) = (%@)", theString, theResult);
   // If the app doesn't override, use the internal default!
-  if ([theResult isEqualToString:theString]) {
+  if (NSOrderedSame == [theResult caseInsensitiveCompare:theString]) {
     NSString *theResult2 = NSLocalizedStringFromTableInBundle(theString, @"libcore", getCurrentLanguageBundle(localeIdentifier), @"");
     //NSLog(@"theResult=%@", theResult3);
     //NSLog(@"DEBUG: theResult2 for (%@) = (%@)", theString, theResult2);

--- a/libcore/SKCore.m
+++ b/libcore/SKCore.m
@@ -126,69 +126,34 @@ NSBundle *getCurrentLanguageBundle(NSString *localeIdentifier) {
 
 NSString*sSKCoreGetLocalisedString(NSString*theString)
 {
-  // As iOS 8 mis re-reports the locale (e.g. returning en_GB when on a device configured
-  // to use zh-Hant), base the locale on the "first preferred language" instead - which
-  // always seems to return the correct value.
-  // This returns e.g. en-GB, zh-Hans, zh-Hant etc.
-  NSString *language = [NSLocale preferredLanguages][0];
-  //NSString *localisation =  [[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0];
-  //NSLog(@"DEBUG: preferredLanguages=%@", language);
-  //NSLog(@"DEBUG: preferredLocalizations=%@", localisation);
-  // Oct 22 08:44:22 Pete-Coles-iPhone-6 EAQNewApp[784] <Warning>: DEBUG: preferredLanguages=pt-BR
-  // Oct 22 08:44:22 Pete-Coles-iPhone-6 EAQNewApp[784] <Warning>: DEBUG: preferredLocalizations=pt
-#ifdef DEBUG
-#endif // DEBUG
-  if ([language isEqualToString:@"zh-HK"]) {
-#ifdef DEBUG
-    //NSLog(@"DEBUG: warning: preferred language is HK! %@", language);
-#endif // DEBUG
-    language = @"zh-Hant";
-  }
-  
-  // Required by iOS 9!
-  // change e.g. pt-br to pt!
-  if ([language hasPrefix:@"pt-"]) {
-    language = @"pt";
-    //NSLog(@"DEBUG: preferredLanguage changed to =%@", language);
-  }
-  
-//#ifdef DEBUG
-//  NSString *localeIdentifierIgnore = [[NSLocale currentLocale] localeIdentifier];
-//  NSLog(@"DEBUG: localeIdentifierIgnore =%@", localeIdentifierIgnore);
-//#endif // DEBUG
-  NSString *localeIdentifier = language;
-#ifdef DEBUG
-  //NSLog(@"DEBUG: localeIdentifier=%@", localeIdentifier);
-#endif // DEBUG
-  
-  // Allow the string to be looked-up from the app.
-  NSString *theResult = NSLocalizedString(theString, nil);
-  //NSLog(@"DEBUG: theResult for (%@) = (%@)", theString, theResult);
-  // If the app doesn't override, use the internal default!
-  if (NSOrderedSame == [theResult caseInsensitiveCompare:theString]) {
-    NSString *theResult2 = NSLocalizedStringFromTableInBundle(theString, @"libcore", getCurrentLanguageBundle(localeIdentifier), @"");
-    //NSLog(@"theResult=%@", theResult3);
-    //NSLog(@"DEBUG: theResult2 for (%@) = (%@)", theString, theResult2);
-    if (theResult2 != nil) {
-      theResult = theResult2;
-    }
-  }
-  
-  if (theResult == nil) {
-    SK_ASSERT(false);
-    return @"";
-  }
-  
-  if (theResult == nil) {
-    // This must NEVER return nil, as it could result in a nil value being added to a dictionary!
-    if (theString == nil) {
-      SK_ASSERT(false);
-      return @"";
+    // Allow the string to be looked-up from the app.
+    NSString *theResult = NSLocalizedString(theString, nil);
+    //NSLog(@"DEBUG: theResult for (%@) = (%@)", theString, theResult);
+    // If the app doesn't override, use the internal default!
+    if ([theResult isEqualToString:theString]) {
+        NSString *theResult2 = NSLocalizedStringFromTable(theString, @"libcore", @"");
+        //NSLog(@"theResult=%@", theResult3);
+        //NSLog(@"DEBUG: theResult2 for (%@) = (%@)", theString, theResult2);
+        if (theResult2 != nil) {
+            theResult = theResult2;
+        }
     }
     
-    SK_ASSERT(false);
-    return theString;
-  }
-  
-  return theResult;
+    if (theResult == nil) {
+        SK_ASSERT(false);
+        return @"";
+    }
+    
+    if (theResult == nil) {
+        // This must NEVER return nil, as it could result in a nil value being added to a dictionary!
+        if (theString == nil) {
+            SK_ASSERT(false);
+            return @"";
+        }
+        
+        SK_ASSERT(false);
+        return theString;
+    }
+    
+    return theResult;
 }


### PR DESCRIPTION
So that we don't cause any unwanted conflicts with the OFCOM app, I've created a release branch for the HK fix. The fixes will go into this branch so that we're not blocked by OFCOM and can still create a branch for OFCA.

This fix changes the call we make to find a localised string from the libcore strings table so thhat we should now be able to make use of the way the OS falls back to a root language file instead of specifically looking for strange localisations like "zhans-hk-gb" or similar. This has been tested on a device running iOS10 and iOS9, as well as a simulator in iOS8. In all cases, a combination of language, region and specialised language (i.e. "Chinese, Traditional (Hong Kong)").