### PR TITLE
Enhanced test failure logging to mirror Android

### DIFF
--- a/libcore/SKGlobalMethods.m
+++ b/libcore/SKGlobalMethods.m
@@ -808,81 +808,114 @@ static NSString *sNetworkTechnologyTypeNotAvailable = @"NA";
 // Note that any existing strings must not be changed, as they're related to the on-device Metrics database.
 + (NSString *) sGetDeviceStringForPlatform:(NSString*)platform {
   // iPhone
-  if ([platform isEqualToString:@"iPhone1,1"]) return @"iPhone 1G";
-  if ([platform isEqualToString:@"iPhone1,2"]) return @"iPhone 3G";
-  if ([platform hasPrefix:@"iPhone1"])         return @"iPhone 3G";
+  if ([platform isEqualToString:@"iPhone1,1"])  return @"iPhone 1G";
+  if ([platform isEqualToString:@"iPhone1,2"])  return @"iPhone 3G";
+  if ([platform hasPrefix:@"iPhone1,"])         return @"iPhone 3G";
   
-  if ([platform isEqualToString:@"iPhone2,1"]) return @"iPhone 3GS";
-  if ([platform hasPrefix:@"iPhone2"])         return @"iPhone 3GS";
+  if ([platform isEqualToString:@"iPhone2,1"])  return @"iPhone 3GS";
+  if ([platform hasPrefix:@"iPhone2,"])         return @"iPhone 3GS";
   
-  if ([platform isEqualToString:@"iPhone3,1"]) return @"iPhone 4 (GSM)";
-  if ([platform isEqualToString:@"iPhone3,2"]) return @"iPhone 4";
-  if ([platform isEqualToString:@"iPhone3,3"]) return @"iPhone 4 (CDMA)";
-  if ([platform hasPrefix:@"iPhone3"])         return @"iPhone 4";
+  if ([platform isEqualToString:@"iPhone3,1"])  return @"iPhone 4 (GSM)";
+  if ([platform isEqualToString:@"iPhone3,2"])  return @"iPhone 4";
+  if ([platform isEqualToString:@"iPhone3,3"])  return @"iPhone 4 (CDMA)";
+  if ([platform hasPrefix:@"iPhone3,"])         return @"iPhone 4";
   
-  if ([platform isEqualToString:@"iPhone4,1"]) return @"iPhone 4s";
-  if ([platform hasPrefix:@"iPhone4"])         return @"iPhone 4s";
+  if ([platform isEqualToString:@"iPhone4,1"])  return @"iPhone 4s";
+  if ([platform hasPrefix:@"iPhone4,"])         return @"iPhone 4s";
   
-  if ([platform isEqualToString:@"iPhone5,1"]) return @"iPhone 5 (GSM)";
-  if ([platform isEqualToString:@"iPhone5,2"]) return @"iPhone 5 (CDMA)";
-  if ([platform isEqualToString:@"iPhone5,3"]) return @"iPhone 5C";
-  if ([platform isEqualToString:@"iPhone5,4"]) return @"iPhone 5C";
-  if ([platform hasPrefix:@"iPhone5"])         return @"iPhone 5";
+  if ([platform isEqualToString:@"iPhone5,1"])  return @"iPhone 5 (GSM)";
+  if ([platform isEqualToString:@"iPhone5,2"])  return @"iPhone 5 (CDMA)";
+  if ([platform isEqualToString:@"iPhone5,3"])  return @"iPhone 5C";
+  if ([platform isEqualToString:@"iPhone5,4"])  return @"iPhone 5C";
+  if ([platform hasPrefix:@"iPhone5,"])         return @"iPhone 5";
   
-  if ([platform isEqualToString:@"iPhone6,1"]) return @"iPhone 5S";
-  if ([platform isEqualToString:@"iPhone6,2"]) return @"iPhone 5S";
-  if ([platform hasPrefix:@"iPhone6"])         return @"iPhone 5S";
+  if ([platform isEqualToString:@"iPhone6,1"])  return @"iPhone 5S";
+  if ([platform isEqualToString:@"iPhone6,2"])  return @"iPhone 5S";
+  if ([platform hasPrefix:@"iPhone6,"])         return @"iPhone 5S";
   
-  if ([platform isEqualToString:@"iPhone7,1"]) return @"iPhone 6 Plus";
-  if ([platform isEqualToString:@"iPhone7,2"]) return @"iPhone 6";
-  if ([platform hasPrefix:@"iPhone7"])         return @"iPhone 6";
+  if ([platform isEqualToString:@"iPhone7,1"])  return @"iPhone 6 Plus";
+  if ([platform isEqualToString:@"iPhone7,2"])  return @"iPhone 6";
+  if ([platform hasPrefix:@"iPhone7,"])         return @"iPhone 6";
   
-  if ([platform isEqualToString:@"iPhone8,1"]) return @"iPhone 6s";
-  if ([platform isEqualToString:@"iPhone8,2"]) return @"iPhone 6s Plus";
-  if ([platform isEqualToString:@"iPhone8,4"]) return @"iPhone SE";
-  if ([platform hasPrefix:@"iPhone"])          return @"iPhone";
+  if ([platform isEqualToString:@"iPhone8,1"])  return @"iPhone 6s";
+  if ([platform isEqualToString:@"iPhone8,2"])  return @"iPhone 6s Plus";
+  if ([platform isEqualToString:@"iPhone8,3"])  return @"iPhone SE";
+  if ([platform isEqualToString:@"iPhone8,4"])  return @"iPhone SE";
+  
+  if ([platform isEqualToString:@"iPhone9,1"])  return @"iPhone 7";
+  if ([platform isEqualToString:@"iPhone9,3"])  return @"iPhone 7";
+  if ([platform isEqualToString:@"iPhone9,2"])  return @"iPhone 7 Plus";
+  if ([platform isEqualToString:@"iPhone9,4"])  return @"iPhone 7 Plus";
+  if ([platform hasPrefix:@"iPhone9,"])         return @"iPhone 7";
+  
+  if ([platform isEqualToString:@"iPhone10,1"]) return @"iPhone 8";
+  if ([platform isEqualToString:@"iPhone10,4"]) return @"iPhone 8";
+  if ([platform isEqualToString:@"iPhone10,2"]) return @"iPhone 8 Plus";
+  if ([platform isEqualToString:@"iPhone10,5"]) return @"iPhone 8 Plus";
+  
+  if ([platform isEqualToString:@"iPhone10,3"]) return @"iPhone X";
+  if ([platform isEqualToString:@"iPhone10,6"]) return @"iPhone X";
+  
+  if ([platform hasPrefix:@"iPhone"])           return @"iPhone";
   
   // iPod
-  if ([platform isEqualToString:@"iPod1,1"])   return @"iPod Touch 1G";
-  if ([platform isEqualToString:@"iPod2,1"])   return @"iPod Touch 2G";
-  if ([platform isEqualToString:@"iPod3,1"])   return @"iPod Touch 3G";
-  if ([platform isEqualToString:@"iPod4,1"])   return @"iPod Touch 4G";
-  if ([platform isEqualToString:@"iPod5,1"])   return @"iPod Touch 5G";
-  if ([platform hasPrefix:@"iPod"])            return @"iPod";
+  if ([platform isEqualToString:@"iPod1,1"])    return @"iPod Touch 1G";
+  if ([platform isEqualToString:@"iPod2,1"])    return @"iPod Touch 2G";
+  if ([platform isEqualToString:@"iPod3,1"])    return @"iPod Touch 3G";
+  if ([platform isEqualToString:@"iPod4,1"])    return @"iPod Touch 4G";
+  if ([platform isEqualToString:@"iPod5,1"])    return @"iPod Touch 5G";
+  if ([platform isEqualToString:@"iPod7,1"])    return @"iPod Touch 6G";
+  if ([platform hasPrefix:@"iPod"])             return @"iPod";
   
   // iPad
-  if ([platform isEqualToString:@"iPad1,1"])   return @"iPad";
-  if ([platform isEqualToString:@"iPad1,2"])   return @"iPad 3G";
-  if ([platform isEqualToString:@"iPad2,1"])   return @"iPad 2 (WiFi)";
-  if ([platform isEqualToString:@"iPad2,2"])   return @"iPad 2 (GSM)";
-  if ([platform isEqualToString:@"iPad2,3"])   return @"iPad 2 (CDMA)";
-  if ([platform isEqualToString:@"iPad2,4"])   return @"iPad 2 (WiFi)";
-  if ([platform isEqualToString:@"iPad2,5"])   return @"iPad Mini (WiFi)";
-  if ([platform isEqualToString:@"iPad2,6"])   return @"iPad Mini (GSM)";
-  if ([platform isEqualToString:@"iPad2,7"])   return @"iPad Mini (CDMA)";
-  if ([platform isEqualToString:@"iPad3,1"])   return @"iPad 3 (WiFi)";
-  if ([platform isEqualToString:@"iPad3,2"])   return @"iPad 3 (CDMA)";
-  if ([platform isEqualToString:@"iPad3,3"])   return @"iPad 3 (GSM)";
-  if ([platform isEqualToString:@"iPad3,4"])   return @"iPad 4 (WiFi)";
-  if ([platform isEqualToString:@"iPad3,5"])   return @"iPad 4 (GSM)";
-  if ([platform isEqualToString:@"iPad3,6"])   return @"iPad 4 (CDMA)";
-  if ([platform isEqualToString:@"iPad4,1"])   return @"iPad Air (WiFi)";
-  if ([platform isEqualToString:@"iPad4,2"])   return @"iPad Air (GSM)";
-  if ([platform isEqualToString:@"iPad4,3"])   return @"iPad Air (CDMA)";
-  if ([platform isEqualToString:@"iPad4,4"])   return @"iPad Mini Retina (WiFi)";
-  if ([platform isEqualToString:@"iPad4,5"])   return @"iPad Mini Retina (CDMA)";
-  if ([platform isEqualToString:@"iPad4,7"])   return @"iPad Mini 3 (WiFi)";
-  if ([platform isEqualToString:@"iPad4,8"])   return @"iPad Mini 3 (CDMA)";
-  if ([platform isEqualToString:@"iPad4,9"])   return @"iPad Mini 3 (CDMA)";
-  if ([platform isEqualToString:@"iPad5,3"])   return @"iPad Air 2 (WiFi)";
-  if ([platform isEqualToString:@"iPad5,4"])   return @"iPad Air 2 (CDMA)";
-  if ([platform hasPrefix:@"iPad"])            return @"iPad";
+  if ([platform isEqualToString:@"iPad1,1"])    return @"iPad";
+  if ([platform isEqualToString:@"iPad1,2"])    return @"iPad 3G";
+  if ([platform isEqualToString:@"iPad2,1"])    return @"iPad 2 (WiFi)";
+  if ([platform isEqualToString:@"iPad2,2"])    return @"iPad 2 (GSM)";
+  if ([platform isEqualToString:@"iPad2,3"])    return @"iPad 2 (CDMA)";
+  if ([platform isEqualToString:@"iPad2,4"])    return @"iPad 2 (WiFi)";
+  if ([platform isEqualToString:@"iPad2,5"])    return @"iPad Mini (WiFi)";
+  if ([platform isEqualToString:@"iPad2,6"])    return @"iPad Mini (GSM)";
+  if ([platform isEqualToString:@"iPad2,7"])    return @"iPad Mini (CDMA)";
+  if ([platform isEqualToString:@"iPad3,1"])    return @"iPad 3 (WiFi)";
+  if ([platform isEqualToString:@"iPad3,2"])    return @"iPad 3 (CDMA)";
+  if ([platform isEqualToString:@"iPad3,3"])    return @"iPad 3 (GSM)";
+  if ([platform isEqualToString:@"iPad3,4"])    return @"iPad 4 (WiFi)";
+  if ([platform isEqualToString:@"iPad3,5"])    return @"iPad 4 (GSM)";
+  if ([platform isEqualToString:@"iPad3,6"])    return @"iPad 4 (CDMA)";
+  if ([platform isEqualToString:@"iPad4,1"])    return @"iPad Air (WiFi)";
+  if ([platform isEqualToString:@"iPad4,2"])    return @"iPad Air (GSM)";
+  if ([platform isEqualToString:@"iPad4,3"])    return @"iPad Air (CDMA)";
+  if ([platform isEqualToString:@"iPad4,4"])    return @"iPad Mini Retina (WiFi)";
+  if ([platform isEqualToString:@"iPad4,5"])    return @"iPad Mini Retina (CDMA)";
+  if ([platform isEqualToString:@"iPad4,7"])    return @"iPad Mini 3 (WiFi)";
+  if ([platform isEqualToString:@"iPad4,8"])    return @"iPad Mini 3 (CDMA)";
+  if ([platform isEqualToString:@"iPad4,9"])    return @"iPad Mini 3 (CDMA)";
+  if ([platform isEqualToString:@"iPad5,1"])    return @"iPad Mini 4 (WiFi)";
+  if ([platform isEqualToString:@"iPad5,3"])    return @"iPad Air 2 (WiFi)";
+  if ([platform isEqualToString:@"iPad5,4"])    return @"iPad Air 2 (CDMA)";
+  
+  if ([platform isEqualToString:@"iPad6,3"])    return @"iPad Pro 9.7\" (WiFi)";
+  if ([platform isEqualToString:@"iPad6,4"])    return @"iPad Pro 9.7\" (Cellular)";
+  if ([platform isEqualToString:@"iPad6,7"])    return @"iPad Pro 12.9\" (WiFi)";
+  if ([platform isEqualToString:@"iPad6,8"])    return @"iPad Pro 12.9\" (Cellular)";
+  if ([platform isEqualToString:@"iPad6,11"])   return @"iPad 5 (WiFi)";
+  if ([platform isEqualToString:@"iPad6,12"])   return @"iPad 5 (Cellular)";
+
+  if ([platform isEqualToString:@"iPad7,1"])    return @"iPad Pro 12.9\" (2nd Gen)";
+  if ([platform isEqualToString:@"iPad7,2"])    return @"iPad Pro 12.9\" (2nd Gen)";
+  if ([platform isEqualToString:@"iPad7,3"])    return @"iPad Pro 10.5\"";
+  if ([platform isEqualToString:@"iPad7,4"])    return @"iPad Pro 10.5\"";
+  
+  if ([platform isEqualToString:@"iPad7,5"])    return @"iPad 6";
+  if ([platform isEqualToString:@"iPad7,6"])    return @"iPad 6";
+  if ([platform hasPrefix:@"iPad"])             return @"iPad";
   
   // Simulators
-  //  if ([platform hasPrefix:@"i386"])        return @"Simulator";
-  //  if ([platform hasPrefix:@"x86_64"])      return @"Simulator";
-  if ([platform isEqualToString:@"i386"])      return [UIDevice currentDevice].model;
-  if ([platform isEqualToString:@"x86_64"])    return [UIDevice currentDevice].model;
+  //  if ([platform hasPrefix:@"i386"])         return @"Simulator";
+  //  if ([platform hasPrefix:@"x86_64"])       return @"Simulator";
+  if ([platform isEqualToString:@"i386"])       return [UIDevice currentDevice].model;
+  if ([platform isEqualToString:@"x86_64"])     return [UIDevice currentDevice].model;
   
   return platform;
 }

--- a/libcore/TestCore/SKClosestTargetTest.h
+++ b/libcore/TestCore/SKClosestTargetTest.h
@@ -12,7 +12,7 @@
 @protocol SKClosestTargetDelegate <NSObject>
 
 - (void)ctdDidCompleteClosestTargetTest:(NSString*)target latency:(double)latency;
-- (void)ctdTestDidFail;
+- (void)ctdTestDidFail:(NSString*)target;
 - (void)ctdDidSendPacket:(NSUInteger)bytes;
 
 //### HG

--- a/libcore/TestCore/SKClosestTargetTest.m
+++ b/libcore/TestCore/SKClosestTargetTest.m
@@ -314,13 +314,15 @@ const int cQueryCountPerServer = 3;
                [self.closestTargetDelegate ctdDidCompleteClosestTargetTest:target latency:lowestLatency];
              } else {
                // If this fails - ultimately - call this!
-               [self.closestTargetDelegate ctdTestDidFail];
+               NSString *target = targets[0];
+               
                // Do not assert here, as that would upset the mock tests which monitor for this!
                // SK_ASSERT(false);
 #ifdef DEBUG
                NSDate *now = [NSDate date];
                NSLog(@"DEBUG: warning - all http-based closest target tests failed, after %g seconds", [now timeIntervalSinceDate:timeStartOfHttpQuery]);
 #endif // DEBUG
+               [self.closestTargetDelegate ctdTestDidFail:target];
              }
            }
          }

--- a/libcore/TestCore/SKTransferOperation.m
+++ b/libcore/TestCore/SKTransferOperation.m
@@ -1305,8 +1305,15 @@ const unsigned char spBlockData[cDefaultBlockDataLength];
   // Failed!
   SK_ASSERT(false);
   
-  [self done];
-  [self doSendUpdateStatus:FAILED threadId:threadId];
+  if([self isCancelled])
+  {
+    [self cancelled];
+  }
+  else
+  {
+    [self done];
+    [self doSendUpdateStatus:FAILED threadId:threadId];
+  }
 }
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError*)error
@@ -1331,12 +1338,13 @@ const unsigned char spBlockData[cDefaultBlockDataLength];
   else
   {
     [self done];
+    [self doSendUpdateStatus:FAILED threadId:threadId];
   }
   
   testOK = NO;
   
   // Whether or not we've already cancelled - send a FAILED status update through.
-  [self doSendUpdateStatus:FAILED threadId:threadId];
+  //[self doSendUpdateStatus:FAILED threadId:threadId];
 }
 
 - (void)connection:(NSURLConnection*)connection didReceiveData:(NSData *)data

--- a/libcore/UICore/SKARunTestsController.m
+++ b/libcore/UICore/SKARunTestsController.m
@@ -83,8 +83,6 @@
 #endif // DEBUG
   [SKGlobalMethods sPerformOnMainThread:^{
 
-    [self cancelTestFromAlertResponse:NO];
-    testsComplete = YES;
     [self.lblClosest setText:sSKCoreGetLocalisedString(@"TEST_Label_Closest_Failed")];
     
     NSIndexPath *ixp = [self getIndexPathForTest:@"latency"];
@@ -318,9 +316,6 @@
     [self updateResultsArray:@NO key:@"HIDE_LABEL" testType:test];
     [self updateResultsArray:@YES key:@"HIDE_SPINNER" testType:test];
     [self updateResultsArray:[SKTransferOperation getStatusFailed] key:@"RESULT_1" testType:test];
-    
-    [self cancelTestFromAlertResponse:NO];
-    testsComplete = YES;
   });
 }
 


### PR DESCRIPTION
This enhances functionality on iOS so that failed JHTTPGETMT and JHTTPPOSTMT tests properly complete, recording results into the database and JSON file where "success" is "false" (like on Android).